### PR TITLE
fixed off by one error

### DIFF
--- a/classify/metadata.coffee
+++ b/classify/metadata.coffee
@@ -5,7 +5,7 @@ ClassifyMetadata =
 
   formattedTimestamp: (ts) ->
     date = new Date(ts)
-    "#{date.getMonth()}-#{date.getDate()}-#{date.getFullYear()}"
+    "#{date.getMonth()+1}-#{date.getDate()}-#{date.getFullYear()}"
 
   setSubject: (subject) -> @subject = subject
 


### PR DESCRIPTION
getMonth returns a zero indexed result, resulting in incorrect months displayed while classifying.