### PR TITLE
Record UTM coords, calculate correct latlongs for coastal intersection

### DIFF
--- a/import-pipeline/color_calibration.py
+++ b/import-pipeline/color_calibration.py
@@ -40,7 +40,7 @@ def process_scene(sceneID, sun_elevation, d):
         bias = get_value_from_file(metadata, "RADIANCE_ADD_BAND_{}".format(band))
         sun_zenith_angle = math.cos(math.radians(90 - sun_elevation))
 
-        #convert calibrated numbers back to radiance, 
+        #convert calibrated numbers back to radiance,
         radiance = im * gain + bias
         reflectance = math.pi * d * radiance / (solar_irradiance * sun_zenith_angle)
 
@@ -52,8 +52,6 @@ def process_scene(sceneID, sun_elevation, d):
         final = 255 * reflectance**(1/gamma)
         bands[band] = final
 
-        os.remove(filename)
-
     #merge and scale bands to 0-255 together to maintain color balance
 
     img = np.zeros((im.shape[0], im.shape[1], 3), dtype=np.float)
@@ -63,9 +61,9 @@ def process_scene(sceneID, sun_elevation, d):
 
     img = skimage.exposure.rescale_intensity(img)
 
-    skimage.io.imsave(os.path.join('temp', sceneID, "{sceneID}_B5.TIF".format(sceneID=sceneID)), img[:, :, 0])
-    skimage.io.imsave(os.path.join('temp', sceneID, "{sceneID}_B4.TIF".format(sceneID=sceneID)), img[:, :, 1])
-    skimage.io.imsave(os.path.join('temp', sceneID, "{sceneID}_B3.TIF".format(sceneID=sceneID)), img[:, :, 2])
+    skimage.io.imsave(os.path.join('temp', sceneID, "{sceneID}_B5_calibrated.TIF".format(sceneID=sceneID)), img[:, :, 0])
+    skimage.io.imsave(os.path.join('temp', sceneID, "{sceneID}_B4_calibrated.TIF".format(sceneID=sceneID)), img[:, :, 1])
+    skimage.io.imsave(os.path.join('temp', sceneID, "{sceneID}_B3_calibrated.TIF".format(sceneID=sceneID)), img[:, :, 2])
 
 
 if __name__ == "__main__":

--- a/import-pipeline/geotiff.py
+++ b/import-pipeline/geotiff.py
@@ -1,0 +1,105 @@
+import sys
+import gdal
+import osr
+import ogr
+
+def get_proj4(ds):
+    # Get proj4 string
+    src = osr.SpatialReference()
+    src.ImportFromWkt(ds.GetProjection())
+    return src.ExportToProj4()
+
+def get_proj_param(ds, param):
+    # Get proj4 string
+    src = osr.SpatialReference()
+    src.ImportFromWkt(ds.GetProjection())
+    # Extract and return required param's value
+    return filter(lambda v: v.find("+"+param+"=") > -1, src.ExportToProj4().split(" "))[0].replace("+"+param+"=", "")
+
+def get_datum(ds):
+    return get_proj_param(ds, "datum")
+
+def get_utm_zone(ds):
+    return get_proj_param(ds, "zone")
+
+def get_pixel_coords_latlng(ds, px, py, datum):
+    # Get coordinate system from file
+    in_cs= osr.SpatialReference()
+    in_cs.ImportFromWkt(ds.GetProjectionRef())
+
+    # Create WGS84 coord system for latlngs
+    wgs84_wkt = """
+    GEOGCS["WGS 84",
+        DATUM["WGS_1984",
+            SPHEROID["WGS 84",6378137,298.257223563,
+                AUTHORITY["EPSG","7030"]],
+            AUTHORITY["EPSG","6326"]],
+        PRIMEM["Greenwich",0,
+            AUTHORITY["EPSG","8901"]],
+        UNIT["degree",0.01745329251994328,
+            AUTHORITY["EPSG","9122"]],
+        AUTHORITY["EPSG","4326"]]"""
+    out_cs = osr.SpatialReference()
+    out_cs .ImportFromWkt(wgs84_wkt)
+
+    # Create point with required x,y
+    xy_utm = get_pixel_coords_utm(ds, px, py)
+    point = ogr.Geometry(ogr.wkbPoint)
+    point.AddPoint(xy_utm[0], xy_utm[1])
+
+    # Transform point from UTM to latlng
+    coord_transform = osr.CoordinateTransformation(in_cs, out_cs)
+    point.Transform(coord_transform)
+
+    # Return point as list
+    return point.GetX(), point.GetY()
+
+
+def get_pixel_coords_utm(ds, px, py):
+    # Get file dimensions
+    width = ds.RasterXSize
+    height = ds.RasterYSize
+
+    # Get coordinate transformation from file
+    gt = ds.GetGeoTransform()
+
+    # Transform pixel coordinates to UTM
+    x0 = gt[0]
+    y0 = gt[3] + width*gt[4] + height*gt[5]
+    x1 = gt[0] + width*gt[1] + height*gt[2]
+    y1 = gt[3]
+    x = gt[0] + px*gt[1] + py*gt[2]
+    y = gt[3] + px*gt[4] + py*gt[5]
+
+    # Return as list
+    return x, y
+
+def get_pixel_coords(ds, type, px, py):
+    # Cast shell args to ints
+    px = int(px) * 1.0
+    py = int(py) * 1.0
+
+    # Return coords in desired CRS
+    if type == "utm":
+        return get_pixel_coords_utm(ds, px, py)
+    elif type == "latlng":
+        return get_pixel_coords_latlng(ds, px, py, "wgs84")
+
+
+if __name__ == "__main__":
+    cmd = sys.argv[1]
+    file = sys.argv[2]
+    args = sys.argv[3:]
+
+    # Load file with gdal
+    ds = gdal.Open(file)
+
+    # Print results of requested op
+    if cmd == "zone":
+        print get_utm_zone(ds, *args)
+    elif cmd == "pixel2coords":
+        print get_pixel_coords(ds, *args)
+    elif cmd == "proj4":
+        print get_proj4(ds)
+    elif cmd == "datum":
+        print get_datum(ds, *args)

--- a/import-pipeline/geotiff.rb
+++ b/import-pipeline/geotiff.rb
@@ -1,0 +1,15 @@
+# Thin wrapper around geotiff.py (ruby-gdal seems to have issues reading GeoTIFFs https://github.com/zhm/gdal-ruby/issues/10)
+
+def get_datum(file)
+    return `python geotiff.py datum #{file}`.tr("\n", "")
+end
+
+def get_utm_zone(file)
+    return `python geotiff.py zone #{file}`.tr("\n", "").to_i
+end
+
+def get_pixel_coords(file, type, x, y)
+    result = `python geotiff.py pixel2coords #{file} #{type} #{x} #{y}`
+    coords = result.tr("(", "").tr(")", "").tr("\n", "").split(",")
+    coords = [coords[0].to_f, coords[1].to_f]
+end


### PR DESCRIPTION
Previously, latlongs for each tile were calculated with linear interpolation, leading to inaccuracies. This results in non-coast tiles being reported as coastal. This PR:

- Calculates the latlongs by using GDAL to query the UTM coords for the upper-right and lower-left pixel and convert them to WGS84.
- Replaces WGS84 latlongs in the created subject manifest with UTM coords

__Caveats__
[I couldn't get ruby-gdal to read GeoTIFFs properly](https://github.com/zhm/gdal-ruby/issues/10), so I used python's bindings to create a small script (`geotiff.py`, wrapped by `geotiff.rb`) to read various data (coords, projection etc) from GeoTIFFs. This has two implications:

1) The script ends up being called multiple times for the same image. It could do with having an option to output, for example, the `geoTransform` for a file to avoid this.
2) Because colour calibration (for LANDSAT 4/5/7 images) and levelling (for LANDSAT 8), which destroy the coordinate data in the GeoTIFF, are called before tiling, we have to create these corrected images as copies, so that we can later extract the various coordinate information we need from the original GeoTIFFs. This will have diskspace implications, but I don't know how much of a concern that is.

To download the smallest dataset I could get the API to return (~650 scenes) would have taken me several days, so I just tested with one scene, but there shouldn't be any issues processing mulltiple scenes.

@aliburchard I think FF are best off reviewing the results of this before this is merged in, what with me not being totally familiar with the dataset. Ran out of time before creating a scenes manifest, but let me know if that's a dealbreaker and I can find the time somewhere.